### PR TITLE
Raise errors close to calling code.

### DIFF
--- a/proposal.rst
+++ b/proposal.rst
@@ -492,6 +492,12 @@ sections on `The start_response() Callable`_ and `Error Handling`_.
 It is used only when the application has trapped an error and is
 attempting to display an error message to the browser.
 
+The ``start_response`` callable **should** perform any header verification and
+checking that will take place before it returns (or raises an error), rather
+than deferring it until body bytes are supplied (either via an iterator or the
+``write`` callable). This ensures that exceptons are raised as close to the
+failing code as possible.
+
 The ``start_response`` callable must return a ``write(body_data)``
 callable that takes one positional parameter: a bytestring to be written
 as part of the HTTP response body.  (Note: the ``write()`` callable is


### PR DESCRIPTION
This is pulled in from the previous set of work we did, and will be proposed for discussion in this form.

Note that I changed the **must** directive to a **should**. This is a deliberate choice: it's not clear to me that all server designs allow for the possibility of ahead-of-time header validation. For that reason, we need to make it clear to application designers that, while server authors will do their best to obey this restriction, they may not be able to.
