### PR TITLE
Define REQUEST_URI environ variable.

### DIFF
--- a/proposal.rst
+++ b/proposal.rst
@@ -627,7 +627,8 @@ unless their value would be an empty string, in which case they
   onwards. It must begin with a leading slash, and **may** contain only that
   slash (if the root was requested). This field is new in WSGI 1.1, and so
   applications must check for the WSGI version tuple before relying on this
-  field.
+  field. This field **must** be a native string, as defined in
+  `A Note On String Types`_.
 
 ``HTTP_`` Variables
   Variables corresponding to the client-supplied HTTP request headers

--- a/proposal.rst
+++ b/proposal.rst
@@ -1378,7 +1378,7 @@ If an application wishes to reconstruct a request's complete URL when
 interoperating with a server using WSGI 1.1, it may do so using the following
 simple algorithm::
 
-    url = environ['wsgi.url_scheme']+'://'
+    url = environ['wsgi.url_scheme'] + '://'
 
     if environ.get('HTTP_HOST'):
         url += environ['HTTP_HOST']
@@ -1400,7 +1400,7 @@ may do so with the somewhat more complex algorithm below, contributed by Ian
 Bicking::
 
     from urllib import quote
-    url = environ['wsgi.url_scheme']+'://'
+    url = environ['wsgi.url_scheme'] + '://'
 
     if environ.get('HTTP_HOST'):
         url += environ['HTTP_HOST']

--- a/proposal.rst
+++ b/proposal.rst
@@ -621,6 +621,14 @@ unless their value would be an empty string, in which case they
   server's response.  However, for compatibility with CGI we have to
   keep the existing name.)
 
+``REQUEST_URI``
+  The complete, un-normalized, raw request URI as provided by the user-agent.
+  This must be everything in the URI from the beginning of the path component
+  onwards. It must begin with a leading slash, and **may** contain only that
+  slash (if the root was requested). This field is new in WSGI 1.1, and so
+  applications must check for the WSGI version tuple before relying on this
+  field.
+
 ``HTTP_`` Variables
   Variables corresponding to the client-supplied HTTP request headers
   (i.e., variables whose names begin with ``"HTTP_"``).  The presence or


### PR DESCRIPTION
This defines the REQUEST_URI variable, which is used to provide the full, un-normalized request URI.
